### PR TITLE
docs: add Authlete MCP setup guide and configuration samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
 ## ✨ 主要機能
 
 ### 🔐 OAuth 2.1 認可サーバー
-- **RFC準拠**: OAuth 2.1 (RFC 6749), PKCE (RFC 7636), OAuth Server Metadata (RFC 8414)
+- **OAuth 2.1 準拠**: 認可コードフロー、PKCE必須 (RFC 7636)
+- **OAuth 拡張機能**: Server Metadata (RFC 8414)、Dynamic Client Registration (RFC 7591/7592)
 - **Authlete統合**: Authlete 3.0 API をバックエンドサービスとして利用
 - **セキュリティ**: HTTPS必須、Bearer Token認証、セッション管理
-- **認証フロー**: 認可コードフロー、同意画面、認可決定処理
 
 ### 🤖 MCP (Model Context Protocol) サーバー
 - **OAuth保護**: スコープベースアクセス制御 (`mcp:tickets:read`, `mcp:tickets:write`)
@@ -167,22 +167,17 @@ sequenceDiagram
 
 ### アーキテクチャの主要ポイント
 
-**OAuth 2.1 準拠機能:**
-- **Authentication Challenge**: 初回アクセス時のWWW-Authenticateヘッダーレスポンス
+**OAuth 2.1 コア機能:**
+- **認可コードフロー**: PKCE必須による安全な認証
+- **Bearer Token認証**: RFC 6750準拠のトークンベース認証
+- **HTTPS必須**: セキュアな通信の強制
+
+**OAuth 拡張機能:**
+- **Server Metadata (RFC 8414)**: `/.well-known/oauth-authorization-server`
+- **Dynamic Client Registration (RFC 7591/7592)**: 動的クライアント登録
 - **Resource Indicators (RFC 8707)**: MCPリソースへのスコープ制限
 - **Authorization Details**: 詳細権限制御（チケット予約の金額制限等）
-- **Dynamic Client Registration (DCR)**: RFC 7591/7592準拠の動的クライアント登録
-
-**Discovery & Metadata (RFC 8414):**
-- **Authorization Server Metadata**: `/.well-known/oauth-authorization-server`
 - **Protected Resource Metadata**: `/.well-known/oauth-protected-resource/mcp`
-
-**セキュリティ機能:**
-- **HTTPS必須**: OAuth 2.1準拠のセキュア通信
-- **PKCE必須**: 認可コードインターセプト攻撃対策
-- **Bearer Token Authentication**: RFC 6750準拠（Authorizationヘッダーのみ）
-- **Resource Scoping**: MCPリソースへのアクセス制限
-- **Scope-based Access Control**: `mcp:tickets:read`/`mcp:tickets:write`
 
 この統合アーキテクチャにより、Claude AIなどのMCPクライアントが、セキュアなOAuth 2.1認証を通じて、チケット販売システムのリソースに安全にアクセスできます。
 
@@ -637,23 +632,26 @@ npm run dev
    - ✅ 認可コードフロー（PKCE必須）
    - ✅ トークンエンドポイント
    - ✅ トークン検証（Introspection）
-   - ✅ Server Metadata (RFC 8414)
-   - ✅ Protected Resource Metadata
    - ✅ Bearer Token認証ミドルウェア
 
-2. **MCP サーバー**
+2. **OAuth 拡張機能**
+   - ✅ Server Metadata (RFC 8414)
+   - ✅ Dynamic Client Registration (RFC 7591/7592)
+   - ✅ Protected Resource Metadata
+
+3. **MCP サーバー**
    - ✅ チケット操作ツール（5種類）
    - ✅ OAuth統合とスコープベース制御
    - ✅ HTTP Streamable対応
    - ✅ 動的認証有効/無効切り替え
 
-3. **構造化ログシステム**
+4. **構造化ログシステム**
    - ✅ 複数ログレベル（5段階）
    - ✅ 環境変数による動的制御
    - ✅ 専用ロガー（OAuth/MCP/Authlete）
    - ✅ JSON構造化出力
 
-4. **統合Webアプリケーション**
+5. **統合Webアプリケーション**
    - ✅ HTTP/HTTPS動的切り替え
    - ✅ セッション管理
    - ✅ 認証・認可
@@ -661,7 +659,9 @@ npm run dev
 
 ### 🏆 技術的成果
 
-- **標準準拠**: OAuth 2.1, RFC 6749/6819/7636/8414, MCP仕様準拠
+- **OAuth 2.1準拠**: 認可コードフロー、PKCE必須 (RFC 7636)、Bearer Token (RFC 6750)
+- **OAuth拡張機能**: Server Metadata (RFC 8414)、DCR (RFC 7591/7592)、Resource Indicators (RFC 8707)
+- **MCP仕様準拠**: Model Context Protocol 完全対応
 - **セキュリティ**: HTTPS必須、PKCE、Bearer Token、スコープベース制御
 - **開発体験**: 構造化ログ、環境変数制御、包括的テストスイート
 - **統合性**: OAuth+MCP+Webアプリのシームレス統合
@@ -688,6 +688,18 @@ npm run dev
 - MCP クライアント SDK 提供
 - OAuth 管理ダッシュボード
 - リアルタイム通知機能
+
+## 📁 設定ファイルとドキュメント
+
+### Authlete 設定復元
+
+現在の Authlete サービス・クライアント設定を MCP で簡単に再作成できるサンプルファイルを提供しています：
+
+- **[Authlete MCP セットアップガイド](docs/authlete-setup.md)** - Claude Code への MCP 追加と設定復元手順
+- **[サービス設定サンプル](examples/authlete-service-config.json)** - OAuth 2.1 サービス設定のJSONテンプレート  
+- **[クライアント設定サンプル](examples/authlete-clients-config.json)** - Confidential/Public クライアント設定のJSONテンプレート
+
+これらのファイルを使用することで、Authlete MCP を通じて同一の設定を素早く復元できます。
 
 ---
 

--- a/docs/authlete-setup.md
+++ b/docs/authlete-setup.md
@@ -1,0 +1,38 @@
+# Authlete MCP セットアップ
+
+## Claude Code への Authlete MCP 追加
+
+### 1. MCPサーバー設定
+`~/.claude/mcp_servers.json` に以下を追加:
+
+```json
+{
+  "authlete": {
+    "command": "docker",
+    "args": [
+      "run", "-i", "--rm",
+      "-e", "ORGANIZATION_ACCESS_TOKEN=your_organization_token",
+      "-e", "ORGANIZATION_ID=your_organization_id",
+      "ghcr.io/watahani/authlete-mcp:latest"
+    ]
+  }
+}
+```
+
+## サービス・クライアント設定復元
+
+### 1. サービス作成
+```bash
+mcp__authlete__create_service_detailed "$(cat examples/authlete-service-config.json)"
+```
+
+### 2. クライアント作成
+```bash
+SERVICE_API_KEY=your_service_api_key
+
+# Confidential Client
+mcp__authlete__create_client "$(jq '.clients[0]' examples/authlete-clients-config.json)" --service_api_key=$SERVICE_API_KEY
+
+# Public Client (MCP)
+mcp__authlete__create_client "$(jq '.clients[1]' examples/authlete-clients-config.json)" --service_api_key=$SERVICE_API_KEY
+```

--- a/examples/authlete-clients-config.json
+++ b/examples/authlete-clients-config.json
@@ -1,0 +1,129 @@
+{
+  "clients": [
+    {
+      "clientName": "Ticket Service Test Client",
+      "description": "Test client for OAuth authorization code flow testing",
+      "clientType": "CONFIDENTIAL",
+      "redirectUris": [
+        "https://localhost:3443/callback",
+        "http://localhost:8080/callback"
+      ],
+      "responseTypes": [
+        "CODE"
+      ],
+      "grantTypes": [
+        "AUTHORIZATION_CODE",
+        "REFRESH_TOKEN"
+      ],
+      "subjectType": "PUBLIC",
+      "idTokenSignAlg": "RS256",
+      "tokenAuthMethod": "CLIENT_SECRET_BASIC",
+      "defaultMaxAge": 0,
+      "authTimeRequired": false,
+      "clientIdAliasEnabled": true,
+      "extension": {
+        "requestableScopesEnabled": false,
+        "accessTokenDuration": 0,
+        "refreshTokenDuration": 0,
+        "tokenExchangePermitted": false,
+        "idTokenDuration": 0
+      },
+      "tlsClientCertificateBoundAccessTokens": false,
+      "bcUserCodeRequired": false,
+      "dynamicallyRegistered": false,
+      "parRequired": false,
+      "requestObjectRequired": false,
+      "frontChannelRequestObjectEncryptionRequired": false,
+      "requestObjectEncryptionAlgMatchRequired": false,
+      "requestObjectEncryptionEncMatchRequired": false,
+      "singleAccessTokenPerSubject": false,
+      "pkceRequired": false,
+      "pkceS256Required": false,
+      "rsRequestSigned": false,
+      "dpopRequired": false,
+      "locked": false,
+      "responseModes": [
+        "QUERY",
+        "FRAGMENT",
+        "FORM_POST",
+        "JWT",
+        "QUERY_JWT",
+        "FRAGMENT_JWT",
+        "FORM_POST_JWT"
+      ],
+      "mtlsEndpointAliasesUsed": false,
+      "trustChainExpiresAt": 0,
+      "trustChainUpdatedAt": 0,
+      "clientRegistrationTypes": [],
+      "automaticallyRegistered": false,
+      "explicitlyRegistered": false,
+      "credentialResponseEncryptionRequired": false
+    },
+    {
+      "clientName": "MCP Client for Ticket Service",
+      "description": "MCP client for accessing ticket service APIs",
+      "clientType": "PUBLIC",
+      "redirectUris": [
+        "http://localhost:8080/mcp/callback",
+        "mcp://localhost/callback",
+        "http://localhost:6274/oauth/callback",
+        "https://localhost:6274/oauth/callback",
+        "https://localhost:3443/oauth/callback",
+        "http://localhost:22396/oauth/callback",
+        "http://localhost/oauth/callback"
+      ],
+      "responseTypes": [
+        "CODE"
+      ],
+      "grantTypes": [
+        "AUTHORIZATION_CODE"
+      ],
+      "subjectType": "PUBLIC",
+      "idTokenSignAlg": "RS256",
+      "tokenAuthMethod": "NONE",
+      "defaultMaxAge": 0,
+      "authTimeRequired": false,
+      "clientIdAliasEnabled": true,
+      "authorizationDetailsTypes": [
+        "ticket-reservation"
+      ],
+      "extension": {
+        "requestableScopesEnabled": false,
+        "accessTokenDuration": 0,
+        "refreshTokenDuration": 0,
+        "tokenExchangePermitted": false,
+        "idTokenDuration": 0
+      },
+      "tlsClientCertificateBoundAccessTokens": false,
+      "bcUserCodeRequired": false,
+      "dynamicallyRegistered": false,
+      "parRequired": false,
+      "requestObjectRequired": false,
+      "frontChannelRequestObjectEncryptionRequired": false,
+      "requestObjectEncryptionAlgMatchRequired": false,
+      "requestObjectEncryptionEncMatchRequired": false,
+      "singleAccessTokenPerSubject": false,
+      "pkceRequired": false,
+      "pkceS256Required": false,
+      "rsRequestSigned": false,
+      "dpopRequired": false,
+      "locked": false,
+      "responseModes": [
+        "QUERY",
+        "FRAGMENT",
+        "FORM_POST",
+        "JWT",
+        "QUERY_JWT",
+        "FRAGMENT_JWT",
+        "FORM_POST_JWT"
+      ],
+      "mtlsEndpointAliasesUsed": false,
+      "trustChainExpiresAt": 0,
+      "trustChainUpdatedAt": 0,
+      "clientRegistrationTypes": [],
+      "automaticallyRegistered": false,
+      "explicitlyRegistered": false,
+      "credentialResponseEncryptionRequired": false
+    }
+  ]
+}

--- a/examples/authlete-service-config.json
+++ b/examples/authlete-service-config.json
@@ -1,0 +1,124 @@
+{
+  "serviceName": "Ticket Service OAuth Server",
+  "issuer": "https://localhost:3443",
+  "description": "OAuth 2.1 Authorization Server for Ticket Sales Service - Study Session 2025-08",
+  "authorizationEndpoint": "https://localhost:3443/oauth/authorize",
+  "tokenEndpoint": "https://localhost:3443/oauth/token",
+  "revocationEndpoint": "https://localhost:3443/oauth/revoke",
+  "userInfoEndpoint": "https://localhost:3443/oauth/userinfo",
+  "jwksUri": "https://localhost:3443/.well-known/jwks.json",
+  "registrationEndpoint": "https://localhost:3443/oauth/register",
+  "introspectionEndpoint": "https://localhost:3443/oauth/introspect",
+  "accessTokenType": "Bearer",
+  "accessTokenDuration": 3600,
+  "refreshTokenDuration": 86400,
+  "idTokenDuration": 3600,
+  "supportedScopes": [
+    {
+      "name": "dcr",
+      "defaultEntry": false,
+      "description": "Dynamic Client Registration access"
+    },
+    {
+      "name": "mcp:tickets:read",
+      "defaultEntry": false,
+      "description": "MCP read access to ticket information via Model Context Protocol"
+    },
+    {
+      "name": "mcp:tickets:write",
+      "defaultEntry": false,
+      "description": "MCP write access to ticket operations via Model Context Protocol"
+    },
+    {
+      "name": "profile:read",
+      "defaultEntry": false,
+      "description": "Read access to user profile information"
+    }
+  ],
+  "supportedResponseTypes": [
+    "CODE"
+  ],
+  "supportedGrantTypes": [
+    "AUTHORIZATION_CODE",
+    "REFRESH_TOKEN"
+  ],
+  "supportedTokenAuthMethods": [
+    "NONE",
+    "CLIENT_SECRET_BASIC",
+    "CLIENT_SECRET_POST"
+  ],
+  "supportedDisplays": [
+    "PAGE"
+  ],
+  "supportedClaimTypes": [
+    "NORMAL"
+  ],
+  "supportedPromptValues": [
+    "NONE",
+    "LOGIN",
+    "CONSENT",
+    "SELECT_ACCOUNT",
+    "CREATE"
+  ],
+  "supportedAuthorizationDetailsTypes": [
+    "ticket-reservation"
+  ],
+  "directAuthorizationEndpointEnabled": true,
+  "directTokenEndpointEnabled": true,
+  "directRevocationEndpointEnabled": true,
+  "directUserInfoEndpointEnabled": true,
+  "directJwksEndpointEnabled": true,
+  "directIntrospectionEndpointEnabled": true,
+  "pkceRequired": true,
+  "pkceS256Required": true,
+  "clientIdAliasEnabled": true,
+  "dynamicRegistrationSupported": true,
+  "singleAccessTokenPerSubject": false,
+  "refreshTokenKept": false,
+  "refreshTokenDurationKept": false,
+  "refreshTokenDurationReset": false,
+  "errorDescriptionOmitted": false,
+  "errorUriOmitted": false,
+  "tlsClientCertificateBoundAccessTokens": false,
+  "mutualTlsValidatePkiCertChain": false,
+  "trustedRootCertificates": [],
+  "allowableClockSkew": 0,
+  "missingClientIdAllowed": false,
+  "parRequired": false,
+  "requestObjectRequired": false,
+  "traditionalRequestObjectProcessingApplied": false,
+  "claimShortcutRestrictive": false,
+  "scopeRequired": false,
+  "nbfOptional": false,
+  "issSuppressed": false,
+  "tokenExpirationLinked": false,
+  "frontChannelRequestObjectEncryptionRequired": false,
+  "requestObjectEncryptionAlgMatchRequired": false,
+  "requestObjectEncryptionEncMatchRequired": false,
+  "hsmEnabled": false,
+  "grantManagementActionRequired": false,
+  "unauthorizedOnClientConfigSupported": false,
+  "dcrScopeUsedAsRequestable": false,
+  "loopbackRedirectionUriVariable": false,
+  "requestObjectAudienceChecked": false,
+  "accessTokenForExternalAttachmentEmbedded": false,
+  "refreshTokenIdempotent": false,
+  "federationEnabled": false,
+  "tokenExchangeByIdentifiableClientsOnly": false,
+  "tokenExchangeByConfidentialClientsOnly": false,
+  "tokenExchangeByPermittedClientsOnly": false,
+  "tokenExchangeEncryptedJwtRejected": false,
+  "tokenExchangeUnsignedJwtRejected": false,
+  "jwtGrantByIdentifiableClientsOnly": false,
+  "jwtGrantEncryptedJwtRejected": false,
+  "jwtGrantUnsignedJwtRejected": false,
+  "dcrDuplicateSoftwareIdBlocked": false,
+  "rsResponseSigned": false,
+  "openidDroppedOnRefreshWithoutOfflineAccess": false,
+  "verifiableCredentialsEnabled": false,
+  "preAuthorizedGrantAnonymousAccessSupported": false,
+  "idTokenReissuable": false,
+  "dpopNonceRequired": false,
+  "clientAssertionAudRestrictedToIssuer": false,
+  "nativeSsoSupported": false
+}


### PR DESCRIPTION
## Summary

- Authlete MCP統合のための包括的なセットアップガイドを追加
- サービス・クライアント作成用のJSONサンプル設定を提供
- `docs/` と `examples/` フォルダでドキュメント整理
- OAuth 2.1コア機能と拡張機能を明確に分離
- README.mdからセットアップドキュメントへのリンクを追加

## 追加ファイル

- **[docs/authlete-setup.md](docs/authlete-setup.md)** - Claude CodeへのAuthlete MCP追加手順
- **[examples/authlete-service-config.json](examples/authlete-service-config.json)** - OAuth 2.1サービス設定テンプレート
- **[examples/authlete-clients-config.json](examples/authlete-clients-config.json)** - クライアント設定テンプレート（Confidential/Public）

## 主な変更

### 📋 新機能
- Authlete MCPサーバーのClaude Code統合方法を詳細説明
- 現在の設定を簡単に復元できるJSONサンプル提供
- Docker経由でのMCPサーバー実行手順

### 📝 ドキュメント改善
- OAuth 2.1標準機能と拡張機能の明確な分離
- 重複していた技術説明の統合・整理
- 設定ファイルの適切なフォルダ構成

## Test plan

- [x] 設定ファイルのJSONフォーマット検証
- [x] ドキュメントリンクの動作確認  
- [x] README.mdの構成改善確認

🤖 Generated with [Claude Code](https://claude.ai/code)