### PR TITLE
feat: add MCP client detection and metadata support in DCR

### DIFF
--- a/examples/authlete-service-config.json
+++ b/examples/authlete-service-config.json
@@ -65,6 +65,9 @@
   "supportedAuthorizationDetailsTypes": [
     "ticket-reservation"
   ],
+  "supportedCustomClientMetadata": [
+    "is_mcp_client"
+  ],
   "directAuthorizationEndpointEnabled": true,
   "directTokenEndpointEnabled": true,
   "directRevocationEndpointEnabled": true,
@@ -100,7 +103,7 @@
   "hsmEnabled": false,
   "grantManagementActionRequired": false,
   "unauthorizedOnClientConfigSupported": false,
-  "dcrScopeUsedAsRequestable": false,
+  "dcrScopeUsedAsRequestable": true,
   "loopbackRedirectionUriVariable": false,
   "requestObjectAudienceChecked": false,
   "accessTokenForExternalAttachmentEmbedded": false,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- DCR で MCP スコープが指定された場合に `is_mcp_client` フラグを自動設定
- サービス設定に `supportedCustomClientMetadata` を追加し `is_mcp_client` をサポート
- `dcrScopeUsedAsRequestable` を有効化してセキュリティを強化

## Changes
- `examples/authlete-service-config.json`: サービス設定の更新
  - `supportedCustomClientMetadata` に `"is_mcp_client"` を追加
  - `dcrScopeUsedAsRequestable` を `true` に設定
- `src/oauth/controllers/dcr.ts`: DCR コントローラーの機能追加
  - `mcp:` プレフィクスのスコープ検出ロジックを追加
  - 検出時に `is_mcp_client: true` を設定
  - Authlete が自動処理する不要なメタデータフィールドを削除

## Test plan
- [ ] DCR でのクライアント登録時に `mcp:tickets:read` などのスコープが含まれている場合、`is_mcp_client` フラグが設定される
- [ ] 通常のスコープのみの場合は `is_mcp_client` フラグが設定されない
- [ ] DCR でのクライアント更新時も同様にフラグが適切に設定される

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)