### PR TITLE
feat: add registrationManagementEndpoint to service config

### DIFF
--- a/examples/authlete-service-config.json
+++ b/examples/authlete-service-config.json
@@ -8,6 +8,7 @@
   "userInfoEndpoint": "https://localhost:3443/oauth/userinfo",
   "jwksUri": "https://localhost:3443/.well-known/jwks.json",
   "registrationEndpoint": "https://localhost:3443/oauth/register",
+  "registrationManagementEndpoint": "https://localhost:3443/oauth/register",
   "introspectionEndpoint": "https://localhost:3443/oauth/introspect",
   "accessTokenType": "Bearer",
   "accessTokenDuration": 3600,


### PR DESCRIPTION
## Summary
- Add `registrationManagementEndpoint` to Authlete service configuration
- Set the same value as `registrationEndpoint` for consistent client registration management

## Changes
- Added `registrationManagementEndpoint` field to `examples/authlete-service-config.json`