### PR TITLE
fix: update Authlete study session date to 2025-08-27

### DIFF
--- a/src/config/mock-database.ts
+++ b/src/config/mock-database.ts
@@ -56,7 +56,7 @@ let users: MockUser[] = [];
 let tickets: MockTicket[] = [
   {
     id: 1,
-    title: 'Authlete勉強会 2025-08',
+    title: 'Authlete勉強会 2025-08-27',
     description: 'OAuth 2.1とMCPプロトコルについて学ぶ勉強会',
     price: 5000.00,
     available_seats: 50,


### PR DESCRIPTION
## Summary
- モックデータベース内のAuthlete勉強会の日付を2025-08-27に更新

## Changes
- `src/config/mock-database.ts` でイベントタイトルの日付を修正

🤖 Generated with [Claude Code](https://claude.ai/code)