### PR TITLE
feat: improve Authlete setup command and add debug logging

### DIFF
--- a/.claude/commands/authlete-setup.md
+++ b/.claude/commands/authlete-setup.md
@@ -12,6 +12,18 @@
    - `ORGANIZATION_ACCESS_TOKEN` と `ORGANIZATION_ID` が設定されている
    - MCP が接続されていない場合は下記のセットアップ手順を実行
 
+### MCP サーバー接続確認
+
+MCP サーバーが正しく接続されているかを確認するには、以下のコマンドを実行します：
+
+```bash
+# Authlete サービス一覧を取得（接続テスト）
+mcp__authlete__list_services
+```
+
+**接続成功の場合**: サービス一覧のJSONレスポンスが返される
+**接続失敗の場合**: エラーメッセージまたは空のレスポンスが返される
+
 2. **プロジェクトファイル**
    - `examples/authlete-service-config.json`（サービス設定）
    - `examples/authlete-clients-config.json`（クライアント設定）

--- a/src/oauth/authlete/client.ts
+++ b/src/oauth/authlete/client.ts
@@ -13,6 +13,7 @@ import {
   AuthleteError
 } from './types/index.js';
 import { AuthleteConfig } from '../config/authlete-config.js';
+import { oauthLogger } from '../../utils/logger.js';
 
 export class AuthleteClient implements AuthleteApiClient {
   private config: AuthleteConfig;
@@ -38,6 +39,12 @@ export class AuthleteClient implements AuthleteApiClient {
         body: JSON.stringify(body)
       });
 
+      oauthLogger.debug('Authlete API Request', {
+        url: url,
+        method: 'POST',
+        body: body
+      });
+
       const responseData = await response.json();
 
       if (!response.ok) {
@@ -58,7 +65,7 @@ export class AuthleteClient implements AuthleteApiClient {
         error.response = responseData as { resultCode?: string; resultMessage?: string };
         throw error;
       }
-
+      oauthLogger.debug('Authlete API Response', responseData);
       return responseData as T;
     } catch (error) {
       if (error instanceof Error && 'status' in error) {
@@ -76,6 +83,11 @@ export class AuthleteClient implements AuthleteApiClient {
   public async makeGetRequest<T>(endpoint: string): Promise<T> {
     const url = `${this.config.baseUrl}/api/${this.config.serviceId}${endpoint}`;
     
+    oauthLogger.debug('Authlete API Request', {
+      url: url,
+      method: 'GET'
+    });
+
     try {
       const response = await fetch(url, {
         method: 'GET',
@@ -104,6 +116,8 @@ export class AuthleteClient implements AuthleteApiClient {
         error.response = responseData as { resultCode?: string; resultMessage?: string };
         throw error;
       }
+
+      oauthLogger.debug('Authlete API Response', responseData);
 
       return responseData as T;
     } catch (error) {
@@ -152,6 +166,19 @@ export class AuthleteClient implements AuthleteApiClient {
         'Authorization': `Bearer ${this.config.serviceAccessToken}`,
         'Content-Type': 'application/json'
       }
+    });
+
+    oauthLogger.debug('service Id and token', {
+      serviceId: this.config.serviceId,
+      serviceAccessToken: this.config.serviceAccessToken
+    });
+
+    oauthLogger.debug('Authlete Service Configuration Response', {
+      status: response.status,
+      statusText: response.statusText,
+      responseData: response.body,
+      url: url,
+      method: 'GET'
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- Add MCP server connection test instructions to `/authlete-setup` command
- Add structured debug logging to Authlete API client for better troubleshooting
- Improve OAuth integration debugging capabilities

## Changes
- `.claude/commands/authlete-setup.md`: Add MCP connection verification section
- `src/oauth/authlete/client.ts`: Add debug logging for API requests and responses

## Test plan
- [x] Verify `/authlete-setup` command documentation is clear
- [x] Test debug logging works with LOG_LEVEL=debug
- [x] Ensure no breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)